### PR TITLE
feat: Add local deployment pipeline for self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, dev, claude/** ]
+    branches: [main, dev, claude/**]
   pull_request:
-    branches: [ main, dev ]
+    branches: [main, dev]
   workflow_dispatch:
 
 permissions:
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: "1.23"
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        go-version: ['1.22', '1.23']
+        go-version: ["1.22", "1.23"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -92,7 +92,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: "1.23"
 
       - name: Build binary
         env:
@@ -118,9 +118,30 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: "1.23"
 
       - name: Verify go.mod and go.sum
         run: |
           go mod tidy
           git diff --exit-code go.mod go.sum
+
+  deploy-local:
+    name: Deploy to Local Environment
+    runs-on: self-hosted
+    needs: [lint, test, build]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Build and deploy for all users
+        run: ./scripts/deploy-local.sh
+
+      - name: Notify deployment complete
+        run: |
+          echo "::notice::Deployed $(git rev-parse --short HEAD) to local environment"

--- a/scripts/SELF-HOSTED-RUNNER.md
+++ b/scripts/SELF-HOSTED-RUNNER.md
@@ -1,0 +1,175 @@
+# Self-Hosted GitHub Actions Runner Setup
+
+This guide explains how to set up a self-hosted GitHub Actions runner for automatic deployment when merging to main.
+
+## Overview
+
+When code is merged to `main`, the CI workflow:
+
+1. Runs lint, test, and build jobs on GitHub-hosted runners
+2. If all pass, triggers `deploy-local` job on the self-hosted runner
+3. The runner executes `scripts/deploy-local.sh` which builds and installs for all users
+
+## Prerequisites
+
+- Linux machine (WSL2 works)
+- Go 1.23+ installed
+- Write access to all user `~/.local/bin` directories
+- Network access to GitHub
+
+## One-Time User Setup
+
+Each user needs `~/.local/bin` directory created. Run as each user or with sudo:
+
+```bash
+# For each user (godev, be-dev-agent, cdev)
+mkdir -p ~/.local/bin
+echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+Or as root:
+
+```bash
+for user in godev be-dev-agent cdev; do
+    sudo -u $user mkdir -p /home/$user/.local/bin
+done
+```
+
+## Setup Instructions
+
+### 1. Create Runner User (Recommended)
+
+Create a dedicated user with permissions to write to all user install directories:
+
+```bash
+# Option A: Add godev to a shared group
+sudo groupadd localbin
+sudo usermod -aG localbin godev
+sudo usermod -aG localbin be-dev-agent
+sudo usermod -aG localbin cdev
+
+# Set group ownership on install directories
+sudo chgrp localbin /home/godev/.local/bin
+sudo chgrp localbin /home/be-dev-agent/.local/bin
+sudo chgrp localbin /home/cdev/.local/bin
+sudo chmod g+w /home/*/.local/bin
+```
+
+### 2. Download and Configure Runner
+
+Navigate to repository Settings > Actions > Runners > New self-hosted runner.
+
+```bash
+# Create directory for runner
+mkdir -p ~/actions-runner && cd ~/actions-runner
+
+# Download runner (check GitHub for latest version)
+curl -o actions-runner-linux-x64-2.321.0.tar.gz -L \
+  https://github.com/actions/runner/releases/download/v2.321.0/actions-runner-linux-x64-2.321.0.tar.gz
+
+# Extract
+tar xzf ./actions-runner-linux-x64-2.321.0.tar.gz
+
+# Configure (get token from GitHub UI)
+./config.sh --url https://github.com/jcaldwell-labs/my-context --token YOUR_TOKEN
+
+# Labels (optional but recommended)
+# When prompted for labels, add: wsl,linux,my-context
+```
+
+### 3. Install as Service
+
+```bash
+# Install service
+sudo ./svc.sh install
+
+# Start service
+sudo ./svc.sh start
+
+# Check status
+sudo ./svc.sh status
+```
+
+### 4. Verify Runner
+
+After setup, the runner should appear in:
+
+- Repository > Settings > Actions > Runners
+
+Status should show "Idle" (ready to receive jobs).
+
+## Testing the Pipeline
+
+1. Create a test branch and make a small change
+2. Open PR, ensure CI passes
+3. Merge to main
+4. Watch Actions tab for `deploy-local` job
+5. Verify installation: `my-context --version` (for each user)
+
+## Troubleshooting
+
+### Runner not picking up jobs
+
+```bash
+# Check service status
+sudo ./svc.sh status
+
+# View logs
+journalctl -u actions.runner.jcaldwell-labs-my-context.$(hostname).service -f
+```
+
+### Permission denied during deploy
+
+Ensure the runner user has write access:
+
+```bash
+# Test write access
+touch /home/godev/.local/bin/test && rm /home/godev/.local/bin/test
+touch /home/be-dev-agent/.local/bin/test && rm /home/be-dev-agent/.local/bin/test
+touch /home/cdev/.local/bin/test && rm /home/cdev/.local/bin/test
+```
+
+### Go not found
+
+Ensure Go is in the runner's PATH:
+
+```bash
+# Add to runner's environment
+echo 'PATH=$PATH:/usr/local/go/bin:$HOME/go/bin' >> ~/actions-runner/.env
+```
+
+## Security Considerations
+
+- Self-hosted runners execute code from the repository
+- Only use with trusted repositories
+- The runner has write access to user directories
+- Consider network isolation if needed
+
+## Workflow Configuration
+
+The deploy job in `.github/workflows/ci.yml`:
+
+```yaml
+deploy-local:
+  name: Deploy to Local Environment
+  runs-on: self-hosted
+  needs: [lint, test, build]
+  if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version: "1.23"
+    - run: ./scripts/deploy-local.sh
+```
+
+## Manual Deployment
+
+If the runner is unavailable, deploy manually:
+
+```bash
+cd ~/projects/go/my-context
+git pull origin main
+./scripts/deploy-local.sh
+```

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# deploy-local.sh - Build and install my-context for all local users
+# Triggered by GitHub Actions self-hosted runner on push to main
+#
+# Usage: ./scripts/deploy-local.sh [--dry-run]
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+BINARY_NAME="my-context"
+
+# Users to install for (must have ~/.local/bin in their PATH)
+USERS=(godev be-dev-agent cdev)
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+DRY_RUN=false
+if [[ "$1" == "--dry-run" ]]; then
+    DRY_RUN=true
+    echo -e "${YELLOW}DRY RUN MODE - no changes will be made${NC}"
+fi
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Change to project directory
+cd "$PROJECT_DIR"
+
+# Get current version from git
+GIT_SHA=$(git rev-parse --short HEAD)
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+log_info "Building my-context from $GIT_BRANCH ($GIT_SHA)"
+
+# Build the binary
+if [[ "$DRY_RUN" == false ]]; then
+    log_info "Compiling binary..."
+    CGO_ENABLED=0 go build -ldflags "-s -w" -o "$BINARY_NAME" ./cmd/my-context/
+
+    if [[ ! -f "$BINARY_NAME" ]]; then
+        log_error "Build failed - binary not created"
+        exit 1
+    fi
+
+    # Verify it runs
+    VERSION=$("./$BINARY_NAME" --version 2>/dev/null || echo "unknown")
+    log_info "Built version: $VERSION"
+else
+    log_info "[DRY RUN] Would compile binary"
+fi
+
+# Install for each user
+INSTALL_COUNT=0
+FAIL_COUNT=0
+
+for USER in "${USERS[@]}"; do
+    USER_HOME=$(getent passwd "$USER" | cut -d: -f6 2>/dev/null || echo "")
+
+    if [[ -z "$USER_HOME" ]]; then
+        log_warn "User $USER not found, skipping"
+        continue
+    fi
+
+    INSTALL_DIR="$USER_HOME/.local/bin"
+    TARGET="$INSTALL_DIR/$BINARY_NAME"
+
+    # Check if install directory exists
+    if [[ ! -d "$INSTALL_DIR" ]]; then
+        log_warn "Install directory $INSTALL_DIR does not exist for $USER, skipping"
+        continue
+    fi
+
+    if [[ "$DRY_RUN" == false ]]; then
+        # Backup existing binary if present
+        if [[ -f "$TARGET" ]]; then
+            OLD_VERSION=$("$TARGET" --version 2>/dev/null || echo "unknown")
+            log_info "Upgrading $USER: $OLD_VERSION -> $VERSION"
+            cp "$TARGET" "$TARGET.backup" 2>/dev/null || true
+        else
+            log_info "Installing for $USER (new installation)"
+        fi
+
+        # Copy and set permissions
+        if cp "$BINARY_NAME" "$TARGET" 2>/dev/null; then
+            chmod +x "$TARGET"
+
+            # Verify installation
+            if "$TARGET" --version >/dev/null 2>&1; then
+                log_info "✓ Installed for $USER"
+                rm -f "$TARGET.backup" 2>/dev/null || true
+                INSTALL_COUNT=$((INSTALL_COUNT + 1))
+            else
+                log_error "✗ Verification failed for $USER, restoring backup"
+                if [[ -f "$TARGET.backup" ]]; then
+                    mv "$TARGET.backup" "$TARGET"
+                fi
+                FAIL_COUNT=$((FAIL_COUNT + 1))
+            fi
+        else
+            log_error "✗ Failed to copy binary for $USER (permission denied?)"
+            FAIL_COUNT=$((FAIL_COUNT + 1))
+        fi
+    else
+        log_info "[DRY RUN] Would install to $TARGET"
+        INSTALL_COUNT=$((INSTALL_COUNT + 1))
+    fi
+done
+
+# Cleanup build artifact
+if [[ "$DRY_RUN" == false ]] && [[ -f "$BINARY_NAME" ]]; then
+    rm "$BINARY_NAME"
+fi
+
+# Summary
+echo ""
+log_info "Deployment complete: $INSTALL_COUNT installed, $FAIL_COUNT failed"
+
+if [[ $FAIL_COUNT -gt 0 ]]; then
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Adds CI/CD integration that automatically builds and installs my-context for all local users when code is merged to main.

- Add `deploy-local` job to CI workflow that runs on a self-hosted runner
- Add `scripts/deploy-local.sh` for building and installing to all configured users (godev, be-dev-agent, cdev)
- Add `scripts/SELF-HOSTED-RUNNER.md` with complete setup instructions

## How it works

1. When a PR is merged to `main`, the CI workflow runs lint, test, and build jobs on GitHub-hosted runners
2. After all jobs pass, the `deploy-local` job is triggered on the self-hosted runner
3. The runner executes `deploy-local.sh` which:
   - Builds the binary from source
   - Installs to `~/.local/bin` for each configured user
   - Backs up existing installations before upgrading
   - Verifies the installation works

## Prerequisites for self-hosted runner

See `scripts/SELF-HOSTED-RUNNER.md` for full setup instructions. Key requirements:

- Self-hosted runner registered with the repository
- Go 1.23+ installed
- Write access to user `~/.local/bin` directories

## Test plan

- [x] Verify `deploy-local.sh --dry-run` works
- [x] Verify actual deployment works for godev user
- [ ] Set up self-hosted runner (manual step)
- [ ] Merge to main and verify automatic deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)