### PR TITLE
fix: Align Go version to 1.24 across CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        go-version: ["1.22", "1.23"]
+        go-version: ["1.24"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -68,7 +68,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.23'
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.24'
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage.out
@@ -98,7 +98,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Build binary
         env:
@@ -127,7 +127,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Verify go.mod and go.sum
         run: |
@@ -146,7 +146,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Build and deploy for all users
         run: ./scripts/deploy-local.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
 
 permissions:
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: "1.24"
 
       - name: Get version info
         id: version


### PR DESCRIPTION
## Summary
- Updated all GitHub Actions workflows to use Go 1.24 to match `go.mod`
- Fixed version inconsistency where CI used 1.22/1.23 and release used 1.25

## Changes
| File | Before | After |
|------|--------|-------|
| ci.yml (lint) | 1.23 | 1.24 |
| ci.yml (test matrix) | [1.22, 1.23] | [1.24] |
| ci.yml (build) | 1.23 | 1.24 |
| ci.yml (verify) | 1.23 | 1.24 |
| ci.yml (deploy-local) | 1.23 | 1.24 |
| release.yml (build) | 1.25 | 1.24 |

## Test plan
- [ ] CI workflow runs successfully with Go 1.24
- [ ] All tests pass on ubuntu-latest, windows-latest, macos-latest
- [ ] Build artifacts generate correctly

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)