### PR TITLE
ci: Add dependabot for Go module security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Dependabot configuration for automated dependency updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+version: 2
+updates:
+  # Go module dependencies
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "go"
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci"


### PR DESCRIPTION
## Summary
- Add Dependabot configuration for automated dependency scanning
- Configure weekly scans for Go module updates (`gomod` ecosystem)
- Configure weekly scans for GitHub Actions updates (`github-actions` ecosystem)
- Auto-label PRs with `dependencies` + `go` or `ci` tags

## Configuration
```yaml
version: 2
updates:
  - package-ecosystem: "gomod"
    directory: "/"
    schedule:
      interval: "weekly"
    open-pull-requests-limit: 5
    labels: ["dependencies", "go"]

  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
    labels: ["dependencies", "ci"]
```

## Test plan
- [x] YAML syntax valid
- [ ] Dependabot activates after merge (check Security tab)
- [ ] First dependency scan runs within a week

Fixes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)