### PR TITLE
fix: Add dependabot for Go module security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+# Dependabot configuration for automated dependency updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Go modules - monitor for security updates and version bumps
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "go"
+
+  # GitHub Actions - keep workflows up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary
- Add Dependabot configuration file for automated dependency monitoring
- Configure weekly scans for Go modules (`gomod` ecosystem)
- Configure weekly scans for GitHub Actions (`github-actions` ecosystem)

## Configuration Details
- **Schedule**: Weekly on Mondays at 9:00 AM ET
- **Go modules**: Up to 10 open PRs, labeled `dependencies` + `go`
- **GitHub Actions**: Up to 5 open PRs, labeled `dependencies` + `github-actions`
- **Commit prefixes**: `deps:` for Go modules, `ci:` for GitHub Actions

## Test plan
- [ ] Verify `.github/dependabot.yml` is valid YAML
- [ ] Confirm Dependabot activates after merge (check repository Insights > Dependency graph > Dependabot)

Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)