### PR TITLE
ci: Add gosec security scanning to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,33 @@ jobs:
           name: my-context-${{ matrix.goos }}-${{ matrix.goarch }}
           path: my-context-${{ matrix.goos }}-${{ matrix.goarch }}*
 
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install X11 development libraries
+        run: sudo apt-get update && sudo apt-get install -y libx11-dev
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: "-no-fail -fmt sarif -out results.sarif ./..."
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+
   verify:
     name: Verify Go modules
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add gosec security scanning job to CI workflow
- Output SARIF results to GitHub Security tab
- Use `-no-fail` flag to surface issues without blocking CI

## Implementation
New `security` job in `.github/workflows/ci.yml` that:
1. Checks out code and sets up Go environment
2. Runs gosec security scanner with SARIF output
3. Uploads findings to GitHub Security tab via CodeQL action v3

## Benefits
- Automated detection of common Go security vulnerabilities:
  - SQL injection
  - Command injection  
  - Hardcoded credentials
  - Insecure file permissions
  - Unhandled errors
- Results visible in repository's Security tab
- Non-blocking initially, can be made strict once baseline is clean

## Test plan
- [ ] CI workflow runs successfully on this PR
- [ ] Security scan job completes
- [ ] SARIF results uploaded (check Security tab after merge)

Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)