### PR TITLE
fix: Add version field to golangci.yml for v9 compatibility

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+version: "1"
 run:
   timeout: 5m
   tests: true


### PR DESCRIPTION
Required by golangci-lint-action v9 update (see #61)

This unblocks the golangci-lint-action bump from v6 to v9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)