### PR TITLE
fix: Log warning instead of silently skipping contexts in tag filter

### DIFF
--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/jefferycaldwell/my-context-copilot/internal/core"
@@ -49,6 +50,7 @@ func filterByTag(contexts []*models.Context, tagFilter string) []*models.Context
 	for _, ctx := range contexts {
 		ctxWithMeta, _, _, _, err := core.GetContextWithMetadata(ctx.Name)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping context %q in tag filter: %v\n", ctx.Name, err)
 			continue
 		}
 		for _, tag := range ctxWithMeta.Metadata.Labels {


### PR DESCRIPTION
## Summary
- Changed `filterByTag` to log warning to stderr when context metadata cannot be read
- Previously, contexts with unreadable metadata were silently excluded from tag filter results
- Users now see `warning: skipping context "name" in tag filter: <error>` for visibility

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes  
- [x] `golangci-lint run` passes
- [ ] Manual test: corrupt a context's meta.json and run `my-context list --tag test`

Fixes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)