### PR TITLE
refactor: Extract duplicated pattern matching to shared utility

### DIFF
--- a/internal/commands/archive.go
+++ b/internal/commands/archive.go
@@ -218,7 +218,7 @@ func filterContextsByPattern(contexts []*models.Context, pattern string) []*mode
 	patternParts := strings.Split(pattern, "*")
 
 	for _, ctx := range contexts {
-		if MatchesPattern(ctx.Name, patternParts) {
+		if core.MatchesPattern(ctx.Name, patternParts) {
 			matches = append(matches, ctx)
 		}
 	}
@@ -332,44 +332,4 @@ func getEnvInt(key string, defaultVal int) int {
 		}
 	}
 	return defaultVal
-}
-
-// MatchesPattern checks if a context name matches a glob pattern (copied from resume.go)
-func MatchesPattern(name string, patternParts []string) bool {
-	if len(patternParts) == 0 {
-		return false // Empty pattern parts means no pattern was split, so no match
-	}
-
-	// Handle the special case of just "*" which should match everything
-	if len(patternParts) == 2 && patternParts[0] == "" && patternParts[1] == "" {
-		return true
-	}
-
-	// Handle simple cases
-	if len(patternParts) == 1 {
-		// No wildcards
-		return name == patternParts[0]
-	}
-
-	// Check prefix
-	if !strings.HasPrefix(name, patternParts[0]) {
-		return false
-	}
-
-	remainingName := name[len(patternParts[0]):]
-
-	// Check suffix
-	lastPart := patternParts[len(patternParts)-1]
-	if !strings.HasSuffix(remainingName, lastPart) {
-		return false
-	}
-
-	// For multiple wildcards, we do a simple substring check
-	for i := 1; i < len(patternParts)-1; i++ {
-		if !strings.Contains(remainingName, patternParts[i]) {
-			return false
-		}
-	}
-
-	return true
 }

--- a/internal/core/pattern.go
+++ b/internal/core/pattern.go
@@ -1,0 +1,46 @@
+package core
+
+import "strings"
+
+// MatchesPattern checks if a context name matches a glob pattern.
+// patternParts should be the result of strings.Split(pattern, "*").
+// Returns false if patternParts is empty (no pattern provided).
+// Returns true if pattern was just "*" (matches everything).
+func MatchesPattern(name string, patternParts []string) bool {
+	if len(patternParts) == 0 {
+		return false // Empty pattern parts means no pattern was split, so no match
+	}
+
+	// Handle the special case of just "*" which should match everything
+	if len(patternParts) == 2 && patternParts[0] == "" && patternParts[1] == "" {
+		return true
+	}
+
+	// Handle simple cases
+	if len(patternParts) == 1 {
+		// No wildcards - exact match required
+		return name == patternParts[0]
+	}
+
+	// Check prefix
+	if !strings.HasPrefix(name, patternParts[0]) {
+		return false
+	}
+
+	remainingName := name[len(patternParts[0]):]
+
+	// Check suffix
+	lastPart := patternParts[len(patternParts)-1]
+	if !strings.HasSuffix(remainingName, lastPart) {
+		return false
+	}
+
+	// For multiple wildcards, we do a simple substring check
+	for i := 1; i < len(patternParts)-1; i++ {
+		if !strings.Contains(remainingName, patternParts[i]) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/core/state.go
+++ b/internal/core/state.go
@@ -179,7 +179,7 @@ func FindContextsByPattern(pattern string) ([]*models.Context, error) {
 	patternParts := strings.Split(pattern, "*")
 
 	for _, ctx := range stoppedContexts {
-		if matchesPattern(ctx.Name, patternParts) {
+		if MatchesPattern(ctx.Name, patternParts) {
 			matches = append(matches, ctx)
 		}
 	}
@@ -191,42 +191,6 @@ func FindContextsByPattern(pattern string) ([]*models.Context, error) {
 	})
 
 	return matches, nil
-}
-
-// matchesPattern checks if a context name matches a glob pattern
-func matchesPattern(name string, patternParts []string) bool {
-	if len(patternParts) == 0 {
-		return true
-	}
-
-	// Handle simple cases
-	if len(patternParts) == 1 {
-		// No wildcards
-		return name == patternParts[0]
-	}
-
-	// Check prefix
-	if !strings.HasPrefix(name, patternParts[0]) {
-		return false
-	}
-
-	remainingName := name[len(patternParts[0]):]
-
-	// Check suffix
-	lastPart := patternParts[len(patternParts)-1]
-	if !strings.HasSuffix(remainingName, lastPart) {
-		return false
-	}
-
-	// For multiple wildcards, we do a simple substring check
-	// This is not a full glob implementation but covers common use cases
-	for i := 1; i < len(patternParts)-1; i++ {
-		if !strings.Contains(remainingName, patternParts[i]) {
-			return false
-		}
-	}
-
-	return true
 }
 
 // FindRelatedContexts finds contexts with similar names (shared prefixes)

--- a/internal/core/state_test.go
+++ b/internal/core/state_test.go
@@ -11,7 +11,8 @@ func TestMatchesPattern(t *testing.T) {
 		patternParts []string
 		want         bool
 	}{
-		{"empty pattern matches all", "any-context", []string{}, true},
+		{"empty pattern returns false", "any-context", []string{}, false},
+		{"single wildcard matches all", "any-context", []string{"", ""}, true},
 		{"no wildcard exact match", "test-context", []string{"test-context"}, true},
 		{"no wildcard no match", "test-context", []string{"other-context"}, false},
 		{"prefix wildcard", "test-context", []string{"test", ""}, true},
@@ -26,9 +27,9 @@ func TestMatchesPattern(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := matchesPattern(tt.contextName, tt.patternParts)
+			got := MatchesPattern(tt.contextName, tt.patternParts)
 			if got != tt.want {
-				t.Errorf("matchesPattern(%q, %v) = %v, want %v", tt.contextName, tt.patternParts, got, tt.want)
+				t.Errorf("MatchesPattern(%q, %v) = %v, want %v", tt.contextName, tt.patternParts, got, tt.want)
 			}
 		})
 	}

--- a/tests/unit/archive_test.go
+++ b/tests/unit/archive_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/jefferycaldwell/my-context-copilot/internal/commands"
+	"github.com/jefferycaldwell/my-context-copilot/internal/core"
 )
 
 // TestGetEnvInt tests the getEnvInt helper function (already tested in note_test.go)
@@ -33,7 +34,7 @@ func TestArchiveGetEnvInt(t *testing.T) {
 	}
 }
 
-// TestMatchesPattern tests the pattern matching functionality (copied from resume tests)
+// TestMatchesPattern tests the pattern matching functionality from core package
 func TestArchiveMatchesPattern(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -68,9 +69,9 @@ func TestArchiveMatchesPattern(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			patternParts := strings.Split(tt.pattern, "*")
-			result := commands.MatchesPattern(tt.contextName, patternParts)
+			result := core.MatchesPattern(tt.contextName, patternParts)
 			if result != tt.expected {
-				t.Errorf("MatchesPattern(%q, %v) = %v, expected %v",
+				t.Errorf("core.MatchesPattern(%q, %v) = %v, expected %v",
 					tt.contextName, patternParts, result, tt.expected)
 			}
 		})


### PR DESCRIPTION
## Summary
- Created `internal/core/pattern.go` with unified `MatchesPattern` function
- Removed duplicate implementations from:
  - `internal/core/state.go` (private `matchesPattern`)
  - `internal/commands/archive.go` (public `MatchesPattern`)
- Net reduction of 28 lines of code (56 added, 84 removed)

## Changes
| File | Change |
|------|--------|
| internal/core/pattern.go | NEW - Single source of truth for pattern matching |
| internal/core/state.go | Uses shared `core.MatchesPattern` |
| internal/commands/archive.go | Uses shared `core.MatchesPattern` |
| internal/core/state_test.go | Updated to test exported function |
| tests/unit/archive_test.go | Updated to use `core.MatchesPattern` |

## Behavior Changes
- Empty `patternParts` now returns `false` (was `true` in state.go)
- This doesn't affect actual usage since callers check for empty pattern before calling

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 44 tests)
- [x] `golangci-lint run` passes
- [x] Pattern matching tests pass in both test files

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)