### PR TITLE
fix: Handle GetActiveContext error in database backend archive path

### DIFF
--- a/internal/commands/archive.go
+++ b/internal/commands/archive.go
@@ -96,7 +96,10 @@ func runSingleArchive(args []string) error {
 		}
 
 		// Prevent archiving active context
-		activeContext, _ := backend.GetActiveContext()
+		activeContext, err := backend.GetActiveContext()
+		if err != nil {
+			return fmt.Errorf("failed to check active context: %w", err)
+		}
 		if activeContext == ctx.Name {
 			return fmt.Errorf("cannot archive active context %q - stop it first", contextName)
 		}


### PR DESCRIPTION
## Summary
Fixed silent error handling in the database backend path of the archive command.

## Problem
```go
activeContext, _ := backend.GetActiveContext()  // ERROR IGNORED
```

If the database query failed, the error was silently ignored, potentially allowing users to archive an active context.

## Solution
Now properly handles the error and returns a descriptive message:
```go
activeContext, err := backend.GetActiveContext()
if err != nil {
    return fmt.Errorf("failed to check active context: %w", err)
}
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes

Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)