### PR TITLE
fix: Add mutual exclusion for --archived and --active-only flags

### DIFF
--- a/internal/commands/list.go
+++ b/internal/commands/list.go
@@ -410,5 +410,8 @@ Supports filtering by project, search term, and archive status.`,
 	cmd.Flags().BoolVar(&showArchived, "archived", false, "Show only archived contexts")
 	cmd.Flags().BoolVar(&activeOnly, "active-only", false, "Show only the active context")
 
+	// Mark mutually exclusive flags
+	cmd.MarkFlagsMutuallyExclusive("archived", "active-only")
+
 	return cmd
 }


### PR DESCRIPTION
## Summary
Added Cobra's `MarkFlagsMutuallyExclusive` to prevent using `--archived` and `--active-only` together in the `list` command.

## Problem
Previously, specifying both flags produced undefined behavior - the filter logic would not apply archive filtering when `activeOnly=true`.

## Solution
```go
cmd.MarkFlagsMutuallyExclusive("archived", "active-only")
```

Now produces a clear error message:
```
Error: if any flags in the group [archived active-only] are set none of the others can be
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes  
- [x] `golangci-lint run` passes
- [x] Manual test: `my-context list --archived --active-only` shows error

Fixes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)