### PR TITLE
fix: Improve date parsing validation and error messages

### DIFF
--- a/internal/commands/archive.go
+++ b/internal/commands/archive.go
@@ -237,15 +237,29 @@ func filterContextsByStopDate(contexts []*models.Context, before time.Time) []*m
 	return filtered
 }
 
-// ParseDateString parses a YYYY-MM-DD date string
+// ParseDateString parses a YYYY-MM-DD date string and returns end of day in local timezone.
+// Trims whitespace and validates the date is valid (rejects dates like 2024-02-30).
 func ParseDateString(dateStr string) (time.Time, error) {
-	// Parse as YYYY-MM-DD and set to end of day
-	parsed, err := time.Parse("2006-01-02", dateStr)
-	if err != nil {
-		return time.Time{}, err
+	// Trim whitespace
+	dateStr = strings.TrimSpace(dateStr)
+	if dateStr == "" {
+		return time.Time{}, fmt.Errorf("date string cannot be empty")
 	}
-	// Set to end of day (23:59:59)
-	return time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 23, 59, 59, 0, parsed.Location()), nil
+
+	// Parse as YYYY-MM-DD in local timezone
+	parsed, err := time.ParseInLocation("2006-01-02", dateStr, time.Local)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid date format (expected YYYY-MM-DD): %w", err)
+	}
+
+	// Validate the date didn't roll over (e.g., 2024-02-30 would become 2024-03-01)
+	// Re-format and compare to catch invalid dates
+	if parsed.Format("2006-01-02") != dateStr {
+		return time.Time{}, fmt.Errorf("invalid date: %s (day out of range for month)", dateStr)
+	}
+
+	// Set to end of day (23:59:59) in local timezone
+	return time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 23, 59, 59, 0, time.Local), nil
 }
 
 // showBulkDryRun displays what would be archived without actually doing it

--- a/tests/unit/archive_test.go
+++ b/tests/unit/archive_test.go
@@ -88,9 +88,13 @@ func TestParseDateString(t *testing.T) {
 	}{
 		{"valid date", "2024-01-15", false, 15},
 		{"leap year", "2024-02-29", false, 29},
+		{"whitespace trimmed", "  2024-01-15  ", false, 15},
 		{"invalid format", "2024/01/15", true, 0},
 		{"invalid date", "2024-13-01", true, 0},
+		{"invalid day rollover", "2024-02-30", true, 0},
+		{"invalid day in april", "2024-04-31", true, 0},
 		{"empty string", "", true, 0},
+		{"whitespace only", "   ", true, 0},
 		{"incomplete date", "2024-01", true, 0},
 	}
 


### PR DESCRIPTION
## Summary
Enhanced `ParseDateString` with better validation and user-friendly error messages.

## Changes
1. **Whitespace trimming** - `" 2024-01-15 "` now works correctly
2. **Date validation** - Rejects invalid dates like `2024-02-30` (would silently roll to March)
3. **Local timezone** - Uses `time.Local` instead of implicit UTC
4. **Better errors** - Clear messages like "invalid date: 2024-02-30 (day out of range for month)"

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [x] New test cases for whitespace and date rollover validation

Fixes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)