### PR TITLE
fix: Correct active context query in partitions command

### DIFF
--- a/internal/commands/partitions.go
+++ b/internal/commands/partitions.go
@@ -185,8 +185,10 @@ func listPartitions(backend interface{}) ([]PartitionInfo, error) {
 		}
 
 		// Get active context using pq.QuoteIdentifier for safe schema quoting
+		// Note: The value is stored as a JSON string (e.g., "context-name"), not an object.
+		// We use trim() to remove the JSON string quotes after casting to text.
 		activeQuery := fmt.Sprintf(`
-			SELECT value->>'name'
+			SELECT trim(both '"' from value::text)
 			FROM %s.state
 			WHERE key = 'active_context'
 		`, pq.QuoteIdentifier(schema))


### PR DESCRIPTION
## Summary

Fixes the `partitions` command always showing `Active: (none)` even when a context is active.

## Root Cause

The query used `value->>'name'` to extract the active context:

```sql
SELECT value->>'name' FROM state WHERE key = 'active_context'
```

But `SetActiveContext()` stores the value as a JSON string (`"context-name"`), not an object (`{"name": "context-name"}`). PostgreSQL's `->>` operator extracts object fields, so it returned NULL for JSON strings.

## Fix

Changed to extract the JSON string value directly:

```sql
SELECT trim(both '"' from value::text) FROM state WHERE key = 'active_context'
```

## Testing

- [x] Build passes
- [x] Lint passes  
- [x] Unit tests pass

## Test plan

```bash
export MY_CONTEXT_HOME=db
my-context start "test-context"
my-context partitions  # Should now show "Active: test-context"
```

Fixes #91

🤖 Generated with [Claude Code](https://claude.ai/claude-code)